### PR TITLE
Updates/cwlp2 264 update extraction logic for scanners

### DIFF
--- a/apps/tradein-admin/src/app/pages/order-management/index.tsx
+++ b/apps/tradein-admin/src/app/pages/order-management/index.tsx
@@ -16,10 +16,14 @@ import { useNavigate } from 'react-router-dom';
 
 export function OrderManagementPage() {
   const navigate = useNavigate();
-  const { state: authState } = useAuth();
-  const { activePlatform } = authState;
+  const {
+    state: authState,
+    getPlatformConfig,
+    clearPlatformConfig,
+  } = useAuth();
+  const { activePlatform, platformConfig } = authState;
   const { state, fetchOrders, clearOrders } = useOrder();
-  const { orders, isFetchingOrders, shipcode } = state;
+  const { orders, isFetchingOrders } = state;
   const { setSearchTerm } = useCommon();
   const { hasViewOrderDetailsPermission } = usePermission();
 
@@ -40,8 +44,9 @@ export function OrderManagementPage() {
     const controller = new AbortController();
     const signal = controller.signal;
 
-    if (!isEmpty(activePlatform)) {
+    if (!isEmpty(activePlatform) || isEmpty(platformConfig)) {
       fetchOrders(signal);
+      getPlatformConfig(activePlatform, signal);
     }
 
     return () => {
@@ -50,12 +55,13 @@ export function OrderManagementPage() {
       // Clear data on unmount
       clearOrders();
       setSearchTerm('');
+      clearPlatformConfig({});
     };
   }, [activePlatform]);
 
   return (
     <>
-      <PageSubHeader withSearch specificString={shipcode} />
+      <PageSubHeader withSearch courierCode={platformConfig?.courier} />
       <Table
         label="Orders"
         isLoading={isFetchingOrders}

--- a/libs/src/components/page-subheader/page-subheader.tsx
+++ b/libs/src/components/page-subheader/page-subheader.tsx
@@ -1,5 +1,7 @@
+/* eslint-disable no-case-declarations */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import styled from 'styled-components';
+import { CourierCodes } from '../../constants';
 import { useCommon } from '../../store';
 import { StyledInput } from '../input';
 
@@ -59,7 +61,7 @@ interface PageSubHeaderProps {
   marginBottom?: string;
   marginLeft?: string;
   marginRight?: string;
-  specificString?: string;
+  courierCode?: string;
 }
 
 export function PageSubHeader({ 
@@ -73,7 +75,7 @@ export function PageSubHeader({
   marginBottom,
   marginLeft,
   marginRight,
-  specificString,
+  courierCode,
 }: PageSubHeaderProps) {
   const { state: commonState, setSearchTerm } = useCommon();
   const { searchTerm } = commonState;
@@ -84,15 +86,36 @@ export function PageSubHeader({
 
     let modifiedText = clipboardData;
 
-    if (specificString) {
-      console.log('SHIPCODE: ', specificString);
-      // Find the position of the specific string
-      const index = clipboardData.indexOf(specificString);
+    switch (courierCode) {
+      case CourierCodes.NZ_POST:
+        // Find the position of "EC1"
+        const ec1Index = clipboardData.indexOf('EC1');
+        
+        if (ec1Index !== -1) {
+          // Extract the part of the string after "EC1"
+          const afterEC1 = clipboardData.slice(ec1Index + 3);
 
-      if (index !== -1) {
-        // Keep the part of the text from the specific string onward
-        modifiedText = clipboardData.slice(index);
-      }
+          // Find the next space after the digits following "EC1"
+          const spaceIndex = afterEC1.indexOf(' ');
+
+          // Extract text between "EC1" and the first space (or until the end if no space is found)
+          modifiedText = spaceIndex !== -1 ? afterEC1.slice(0, spaceIndex) : afterEC1.trim();
+        }
+        break;
+
+      case CourierCodes.SHIP_ENGINE:
+        // Find the position of "349GY"
+        const index = clipboardData.indexOf('349GY');
+
+        if (index !== -1) {
+          // Keep the part of the text from the specified string onward
+          modifiedText = clipboardData.slice(index);
+        }
+        break;
+    
+      default:
+        modifiedText = clipboardData;
+        break;
     }
 
     setSearchTerm(modifiedText);

--- a/libs/src/constants/enums.ts
+++ b/libs/src/constants/enums.ts
@@ -203,3 +203,8 @@ export enum StripeErrorCodes {
   RESOURCE_MISSING = 'resource_missing',
   UNKNOWN_ERROR = 'unknown_error'
 }
+
+export enum CourierCodes {
+  SHIP_ENGINE = 'shipengine',
+  NZ_POST = 'nzpost'
+}

--- a/libs/src/store/order/reducer.ts
+++ b/libs/src/store/order/reducer.ts
@@ -43,7 +43,6 @@ const orderState = {
   isUpdatingDeviceLockStatus: false,
   isUpdatingLockedDeviceStatus: false,
   isUpdatingOrderItemPaymentStatus: false,
-  shipcode: '' || undefined,
   isRequestingOrderItemPayment: false,
 };
 
@@ -61,7 +60,6 @@ const orderReducer = (state = orderState, action: any) => {
         ...state,
         isFetchingOrders: false,
         orders: action.payload?.data,
-        shipcode: action.payload?.shipcode || undefined,
       };
     }
     case types.FETCH_ORDERS.FAILED: {


### PR DESCRIPTION
This PR includes the following changes:

- [x] Added courier codes enum
- [x] Remove unnecessary/unused state declarations
- [x] Added fetching of platform config in order management page
- [x] Update extraction logic for scanners to support both nzpost and shipengine codes