### PR TITLE
Feature/mipp 172 date filters followup devices

### DIFF
--- a/apps/tradein-admin/src/app/pages/actionables/followup-revision-offer/index.tsx
+++ b/apps/tradein-admin/src/app/pages/actionables/followup-revision-offer/index.tsx
@@ -1,14 +1,24 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
 import {
+  AppButton,
   CenterModal,
+  Divider,
+  FOLLOW_UP_DAYS_FILTER,
+  FormGroup,
+  FormWrapper,
+  IconButton,
   Loader,
+  MODAL_TYPES,
   openInNewTab,
   OrderItemStatus,
   Pages,
   PageSubHeader,
   REVISED_DEVICES_MANAGEMENT_COLUMNS,
   revisedDevicesManagementParsingConfig,
+  SideModal,
+  StyledReactSelect,
   Table,
   useAuth,
   useCommon,
@@ -24,9 +34,12 @@ export function FollowUpRevisionOfferPage() {
   const { orders, order, isFetchingOrders } = state;
   const { state: authState } = useAuth();
   const { activePlatform } = authState;
-  const { setSearchTerm } = useCommon();
+  const { state: commonState, setSideModalState, setSearchTerm } = useCommon();
+  const { sideModalState } = commonState;
   const [selectedRow, setSelectedRow] = useState<any>({});
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [dateFilter, setDateFilter] = useState<any>('');
+  const [selectedDaysFilter, setSelectedDaysFilter] = useState<any>(dateFilter);
 
   const headers = REVISED_DEVICES_MANAGEMENT_COLUMNS;
 
@@ -82,14 +95,142 @@ export function FollowUpRevisionOfferPage() {
   }, [activePlatform]);
 
   const filteredOrders = useMemo(() => {
-    return orders.filter((order: any) =>
-      hasUnsentOrderItems(order?.order_items),
-    );
-  }, [orders]);
+    const daysMapping: Record<string, number[]> = {
+      2: [0, 2],
+      4: [3, 4],
+      6: [5, 6],
+      7: [7, Infinity],
+    };
+
+    return orders.filter((order: any) => {
+      const unsentItems = hasUnsentOrderItems(order?.order_items);
+
+      if (!dateFilter) {
+        return unsentItems;
+      }
+
+      const [minDays, maxDays] = daysMapping[dateFilter] || [0, Infinity];
+
+      const createdAtDate = new Date(order?.createdAt);
+      const currentDate = new Date();
+
+      const diffInDays = Math.floor(
+        (currentDate.getTime() - createdAtDate.getTime()) /
+          (1000 * 60 * 60 * 24),
+      );
+
+      const isInDateRange = diffInDays >= minDays && diffInDays <= maxDays;
+
+      return unsentItems && isInDateRange;
+    });
+  }, [orders, dateFilter]);
+
+  const resetFilters = () => {
+    setSelectedDaysFilter('');
+  };
+
+  const cancelFilters = () => {
+    setDateFilter(dateFilter);
+    if (dateFilter) {
+      setSelectedDaysFilter({ ...selectedDaysFilter, value: dateFilter });
+    } else {
+      setSelectedDaysFilter('');
+    }
+
+    setSideModalState({
+      ...sideModalState,
+      open: false,
+      view: null,
+    });
+  };
+
+  const renderSideModalContent = () => {
+    switch (sideModalState.view) {
+      case MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES:
+        return (
+          <FormWrapper formTitle="Filter By">
+            <FormGroup marginBottom="20px">
+              <StyledReactSelect
+                label="Days Filter"
+                name="days"
+                options={FOLLOW_UP_DAYS_FILTER}
+                isMulti={false}
+                placeholder="Set days filter"
+                value={selectedDaysFilter?.value}
+                onChange={(selectedOption) => {
+                  setSelectedDaysFilter(selectedOption);
+                }}
+              />
+            </FormGroup>
+            <FormGroup>
+              <AppButton
+                type="button"
+                variant="outlined"
+                width="fit-content"
+                onClick={() => resetFilters()}
+                disabled={isEmpty(selectedDaysFilter)}
+              >
+                Reset
+              </AppButton>
+              <FormGroup>
+                <AppButton
+                  type="button"
+                  variant="outlined"
+                  width="fit-content"
+                  onClick={cancelFilters}
+                >
+                  Cancel
+                </AppButton>
+                <AppButton
+                  type="button"
+                  width="fit-content"
+                  onClick={() => {
+                    setDateFilter(selectedDaysFilter.value);
+                    setSideModalState({
+                      ...sideModalState,
+                      open: false,
+                      view: null,
+                    });
+                  }}
+                  disabled={
+                    dateFilter === selectedDaysFilter.value ||
+                    (isEmpty(dateFilter) && isEmpty(selectedDaysFilter))
+                  }
+                >
+                  Apply
+                </AppButton>
+              </FormGroup>
+            </FormGroup>
+          </FormWrapper>
+        );
+
+      default:
+        return;
+    }
+  };
 
   return (
     <>
-      <PageSubHeader withSearch />
+      <PageSubHeader
+        withSearch
+        rightControls={
+          <>
+            <IconButton
+              tooltipLabel="Filter"
+              icon={faFilter}
+              onClick={() => {
+                setSideModalState({
+                  ...sideModalState,
+                  open: true,
+                  view: MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES,
+                });
+              }}
+              disabled={isFetchingOrders}
+            />
+            <Divider />
+          </>
+        }
+      />
       <Table
         label="Follow-Up Revision Offer"
         isLoading={isFetchingOrders}
@@ -123,6 +264,9 @@ export function FollowUpRevisionOfferPage() {
           )}
         </div>
       </CenterModal>
+      <SideModal isOpen={sideModalState?.open} onClose={cancelFilters}>
+        {renderSideModalContent()}
+      </SideModal>
     </>
   );
 }

--- a/apps/tradein-admin/src/app/pages/actionables/followup-unsent-device/index.tsx
+++ b/apps/tradein-admin/src/app/pages/actionables/followup-unsent-device/index.tsx
@@ -1,12 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
+import { faFilter } from '@fortawesome/free-solid-svg-icons';
 import {
+  AppButton,
   CenterModal,
+  Divider,
+  FOLLOW_UP_DAYS_FILTER,
+  FormGroup,
+  FormWrapper,
+  IconButton,
   Loader,
+  MODAL_TYPES,
   openInNewTab,
   OrderItemStatus,
   Pages,
   PageSubHeader,
+  SideModal,
+  StyledReactSelect,
   Table,
   UNSENT_DEVICES_MANAGEMENT_COLUMNS,
   unsentDevicesManagementParsingConfig,
@@ -24,9 +34,12 @@ export function FollowUpUnsentDevicePage() {
   const { orders, order, isFetchingOrders } = state;
   const { state: authState } = useAuth();
   const { activePlatform } = authState;
-  const { setSearchTerm } = useCommon();
+  const { state: commonState, setSideModalState, setSearchTerm } = useCommon();
+  const { sideModalState } = commonState;
   const [selectedRow, setSelectedRow] = useState<any>({});
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [dateFilter, setDateFilter] = useState<any>('');
+  const [selectedDaysFilter, setSelectedDaysFilter] = useState<any>(dateFilter);
 
   const headers = UNSENT_DEVICES_MANAGEMENT_COLUMNS;
 
@@ -81,14 +94,142 @@ export function FollowUpUnsentDevicePage() {
   }, [activePlatform]);
 
   const filteredOrders = useMemo(() => {
-    return orders.filter((order: any) =>
-      hasUnsentOrderItems(order?.order_items),
-    );
-  }, [orders]);
+    const daysMapping: Record<string, number[]> = {
+      2: [0, 2],
+      4: [3, 4],
+      6: [5, 6],
+      7: [7, Infinity],
+    };
+
+    return orders.filter((order: any) => {
+      const unsentItems = hasUnsentOrderItems(order?.order_items);
+
+      if (!dateFilter) {
+        return unsentItems;
+      }
+
+      const [minDays, maxDays] = daysMapping[dateFilter] || [0, Infinity];
+
+      const createdAtDate = new Date(order?.createdAt);
+      const currentDate = new Date();
+
+      const diffInDays = Math.floor(
+        (currentDate.getTime() - createdAtDate.getTime()) /
+          (1000 * 60 * 60 * 24),
+      );
+
+      const isInDateRange = diffInDays >= minDays && diffInDays <= maxDays;
+
+      return unsentItems && isInDateRange;
+    });
+  }, [orders, dateFilter]);
+
+  const resetFilters = () => {
+    setSelectedDaysFilter('');
+  };
+
+  const cancelFilters = () => {
+    setDateFilter(dateFilter);
+    if (dateFilter) {
+      setSelectedDaysFilter({ ...selectedDaysFilter, value: dateFilter });
+    } else {
+      setSelectedDaysFilter('');
+    }
+
+    setSideModalState({
+      ...sideModalState,
+      open: false,
+      view: null,
+    });
+  };
+
+  const renderSideModalContent = () => {
+    switch (sideModalState.view) {
+      case MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES:
+        return (
+          <FormWrapper formTitle="Filter By">
+            <FormGroup marginBottom="20px">
+              <StyledReactSelect
+                label="Days Filter"
+                name="days"
+                options={FOLLOW_UP_DAYS_FILTER}
+                isMulti={false}
+                placeholder="Set days filter"
+                value={selectedDaysFilter?.value}
+                onChange={(selectedOption) => {
+                  setSelectedDaysFilter(selectedOption);
+                }}
+              />
+            </FormGroup>
+            <FormGroup>
+              <AppButton
+                type="button"
+                variant="outlined"
+                width="fit-content"
+                onClick={() => resetFilters()}
+                disabled={isEmpty(selectedDaysFilter)}
+              >
+                Reset
+              </AppButton>
+              <FormGroup>
+                <AppButton
+                  type="button"
+                  variant="outlined"
+                  width="fit-content"
+                  onClick={cancelFilters}
+                >
+                  Cancel
+                </AppButton>
+                <AppButton
+                  type="button"
+                  width="fit-content"
+                  onClick={() => {
+                    setDateFilter(selectedDaysFilter.value);
+                    setSideModalState({
+                      ...sideModalState,
+                      open: false,
+                      view: null,
+                    });
+                  }}
+                  disabled={
+                    dateFilter === selectedDaysFilter.value ||
+                    (isEmpty(dateFilter) && isEmpty(selectedDaysFilter))
+                  }
+                >
+                  Apply
+                </AppButton>
+              </FormGroup>
+            </FormGroup>
+          </FormWrapper>
+        );
+
+      default:
+        return;
+    }
+  };
 
   return (
     <>
-      <PageSubHeader withSearch />
+      <PageSubHeader
+        withSearch
+        rightControls={
+          <>
+            <IconButton
+              tooltipLabel="Filter"
+              icon={faFilter}
+              onClick={() => {
+                setSideModalState({
+                  ...sideModalState,
+                  open: true,
+                  view: MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES,
+                });
+              }}
+              disabled={isFetchingOrders}
+            />
+            <Divider />
+          </>
+        }
+      />
       <Table
         label="Follow-Up Device Not Sent"
         isLoading={isFetchingOrders}
@@ -122,6 +263,9 @@ export function FollowUpUnsentDevicePage() {
           )}
         </div>
       </CenterModal>
+      <SideModal isOpen={sideModalState?.open} onClose={cancelFilters}>
+        {renderSideModalContent()}
+      </SideModal>
     </>
   );
 }

--- a/apps/tradein-admin/src/app/pages/order-management/edit-order/validation-offer.tsx
+++ b/apps/tradein-admin/src/app/pages/order-management/edit-order/validation-offer.tsx
@@ -137,12 +137,12 @@ const ValidationOffer = ({
                     <CardDetail
                       key={idx}
                       label={
-                        formatQuestion(item.question)?.toLocaleLowerCase() ===
+                        formatQuestion(item?.question)?.toLocaleLowerCase() ===
                         'accessories assessment'
                           ? 'Charger Assessment'
-                          : formatQuestion(item.question)
+                          : formatQuestion(item?.question)
                       }
-                      value={deviceValidation(item.answer)}
+                      value={deviceValidation(item?.answer)}
                     />
                   );
                   // return (

--- a/libs/src/components/modal/center-modal.tsx
+++ b/libs/src/components/modal/center-modal.tsx
@@ -40,7 +40,11 @@ const CenterModalWrapper = styled.div<{ isOpen: boolean }>`
   max-height: calc(100vh - 100px);
 `;
 
-export function CenterModal({ isOpen, onClose, children, title }: CenterModalProps): JSX.Element {
+export function CenterModal({ isOpen, onClose, children, title }: CenterModalProps): JSX.Element | null {
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <>
       <Overlay isOpen={isOpen} />

--- a/libs/src/components/modal/generic-modal.tsx
+++ b/libs/src/components/modal/generic-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 
 interface ModalProps {
@@ -8,7 +8,6 @@ interface ModalProps {
   footer?: React.ReactNode;
   isOpen: boolean;
   onClose: () => void;
-  onOpen?: () => void;
 }
 
 const Overlay = styled.div<{ isOpen: boolean }>`
@@ -57,12 +56,10 @@ const ModalFooter = styled.div`
   margin-top: 20px;
 `;
 
-export function GenericModal({ title, subtitle, content, footer, isOpen, onClose, onOpen }: ModalProps): JSX.Element {
-  useEffect(() => {
-    if (isOpen && onOpen) {
-      onOpen();
-    }
-  }, [isOpen, onOpen]);
+export function GenericModal({ title, subtitle, content, footer, isOpen, onClose }: ModalProps): JSX.Element | null {
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <>

--- a/libs/src/components/modal/side-modal.tsx
+++ b/libs/src/components/modal/side-modal.tsx
@@ -19,7 +19,7 @@ const Overlay = styled.div<{ isOpen: boolean }>`
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
   display: ${(props) => (props.isOpen ? 'block' : 'none')};
-  z-index: 1000; /* Lower z-index than modal */
+  z-index: 1005; /* Lower z-index than modal */
 `;
 
 const SideModalWrapper = styled.div<{ isOpen: boolean }>`
@@ -29,7 +29,7 @@ const SideModalWrapper = styled.div<{ isOpen: boolean }>`
   height: 100%;
   background-color: #fff;
   box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);
-  z-index: 1001;
+  z-index: 1006;
   padding: 20px;
   transition: right 0.3s ease-in-out;
   overflow-y: auto;

--- a/libs/src/components/modal/status-modal.tsx
+++ b/libs/src/components/modal/status-modal.tsx
@@ -34,7 +34,11 @@ const CenterModalWrapper = styled.div<{ isOpen: boolean }>`
   max-height: 100%;
 `;
 
-export function StatusModal({ isOpen, onClose, children }: CenterModalProps): JSX.Element {
+export function StatusModal({ isOpen, onClose, children }: CenterModalProps): JSX.Element | null {
+  if (!isOpen) {
+    return null;
+  }
+
   return (
     <>
       <Overlay isOpen={isOpen} onClick={() => onClose()}/>

--- a/libs/src/constants/constants.tsx
+++ b/libs/src/constants/constants.tsx
@@ -27,6 +27,7 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import {
   ClaimStatus,
+  FollowUpDaysFilter,
   LockTypes,
   OrderItemStatus,
   PermissionCodes,
@@ -599,7 +600,7 @@ export const CURRENCIES = [
   { value: 'TJS', label: 'Tajikistani Somoni (TJS)' },
   { value: 'TMT', label: 'Turkmenistani Manat (TMT)' },
   { value: 'TND', label: 'Tunisian Dinar (TND)' },
-  { value: 'TOP', label: "Tongan Pa'anga (TOP)" },
+  { value: 'TOP', label: 'Tongan Pa\'anga (TOP)' },
   { value: 'TRY', label: 'Turkish Lira (TRY)' },
   { value: 'TTD', label: 'Trinidad and Tobago Dollar (TTD)' },
   { value: 'TVD', label: 'Tuvaluan Dollar (TVD)' },
@@ -882,6 +883,7 @@ export const MODAL_TYPES = {
   FILTER_LOCKED_DEVICES_CURRENT_LOCK: 'FILTER_LOCKED_DEVICES_CURRENT_LOCK',
   FILTER_LOCKED_DEVICES_FOR_RETEST: 'FILTER_LOCKED_DEVICES_FOR_RETEST',
   FILTER_DEVICES_WITH_BOX: 'FILTER_DEVICES_WITH_BOX',
+  FILTER_FOLLOW_UP_DEVICES: 'FILTER_FOLLOW_UP_DEVICES',
 };
 
 export const PROMOTION_STATUS = [
@@ -1055,6 +1057,13 @@ export const LOCK_TYPES = [
   { value: LockTypes.PASSCODE, label: 'Passcode' },
   { value: LockTypes.SAMSUNG, label: 'Samsung' },
   { value: LockTypes.OTHERS, label: 'Others' },
+];
+
+export const FOLLOW_UP_DAYS_FILTER = [
+  { value: FollowUpDaysFilter.TWO, label: '1-2 Days' },
+  { value: FollowUpDaysFilter.FOUR, label: '3-4 Days' },
+  { value: FollowUpDaysFilter.SIX, label: '5-6 Days' },
+  { value: FollowUpDaysFilter.SEVEN, label: '7+ Days' },
 ];
 
 export const PAGE_SIZES = [

--- a/libs/src/constants/enums.ts
+++ b/libs/src/constants/enums.ts
@@ -237,3 +237,10 @@ export enum PaymentFlow {
   AUTO = 'auto',
   MANUAL = 'manual',
 }
+
+export enum FollowUpDaysFilter {
+  TWO = '2',
+  FOUR = '4',
+  SIX = '6',
+  SEVEN = '7',
+}

--- a/libs/src/constants/interfaces.ts
+++ b/libs/src/constants/interfaces.ts
@@ -59,7 +59,7 @@ export interface PlatformType {
 export interface RadioOption {
   label: string;
   value: string;
-};
+}
 
 export interface RadioGroupProps {
   options: RadioOption[];
@@ -103,4 +103,9 @@ export interface PromotionClaimsExportData {
   moorup_status: string;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface SelectedDaysFilter {
+  value: '2' | '4' | '6' | '7';
+  label: string;
 }


### PR DESCRIPTION
This PR includes the following changes:

- [x] Fix white screen bug on order details page if questions_answered field is empty
- [x] Update centered modal behavior if modal state is false (not open)
- [x] Added enums and constants for date filters
- [x] Added created date filter for devices for follow-up actionables (All 3 Follow-Up pages)