### PR TITLE
[MIPP-440] Add "Quick Action" Filter buttons to pages

### DIFF
--- a/apps/tradein-admin/src/app/pages/actionables/followup-recycle-offer/index.tsx
+++ b/apps/tradein-admin/src/app/pages/actionables/followup-recycle-offer/index.tsx
@@ -1,15 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
-import { faFilter, faSliders } from '@fortawesome/free-solid-svg-icons';
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
 import {
-  AppButton,
+  ACTIONABLES_FOLLOW_UP_DEVICES_TABS,
   CenterModal,
   Column,
   CustomizeColumns,
   Divider,
-  FOLLOW_UP_DAYS_FILTER,
-  FormGroup,
-  FormWrapper,
+  Dropdown,
   IconButton,
   Loader,
   MODAL_TYPES,
@@ -20,7 +18,6 @@ import {
   REVISED_DEVICES_MANAGEMENT_COLUMNS,
   revisedDevicesManagementParsingConfig,
   SideModal,
-  StyledReactSelect,
   Table,
   useAuth,
   useCommon,
@@ -41,7 +38,6 @@ export function FollowUpRecycleOfferPage() {
   const [selectedRow, setSelectedRow] = useState<any>({});
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [dateFilter, setDateFilter] = useState<any>('');
-  const [selectedDaysFilter, setSelectedDaysFilter] = useState<any>(dateFilter);
 
   const customizedColumns = JSON.parse(localStorage.getItem('CC') || '{}');
   const savedColumns =
@@ -53,6 +49,8 @@ export function FollowUpRecycleOfferPage() {
   const [headers, setHeaders] = useState<Column[]>(
     savedColumns ?? defaultColumns,
   );
+
+  const pageTabs: any = [...ACTIONABLES_FOLLOW_UP_DEVICES_TABS];
 
   const filters = {
     page: Pages.RECYCLE_OFFER,
@@ -136,18 +134,7 @@ export function FollowUpRecycleOfferPage() {
     });
   }, [orders, dateFilter]);
 
-  const resetFilters = () => {
-    setSelectedDaysFilter('');
-  };
-
-  const cancelFilters = () => {
-    setDateFilter(dateFilter);
-    if (dateFilter) {
-      setSelectedDaysFilter({ ...selectedDaysFilter, value: dateFilter });
-    } else {
-      setSelectedDaysFilter('');
-    }
-
+  const closeModal = () => {
     setSideModalState({
       ...sideModalState,
       open: false,
@@ -157,64 +144,6 @@ export function FollowUpRecycleOfferPage() {
 
   const renderSideModalContent = () => {
     switch (sideModalState.view) {
-      case MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES:
-        return (
-          <FormWrapper formTitle="Filter By">
-            <FormGroup marginBottom="20px">
-              <StyledReactSelect
-                label="Days Filter"
-                name="days"
-                options={FOLLOW_UP_DAYS_FILTER}
-                isMulti={false}
-                placeholder="Set days filter"
-                value={selectedDaysFilter?.value}
-                onChange={(selectedOption) => {
-                  setSelectedDaysFilter(selectedOption);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <AppButton
-                type="button"
-                variant="outlined"
-                width="fit-content"
-                onClick={() => resetFilters()}
-                disabled={isEmpty(selectedDaysFilter)}
-              >
-                Reset
-              </AppButton>
-              <FormGroup>
-                <AppButton
-                  type="button"
-                  variant="outlined"
-                  width="fit-content"
-                  onClick={cancelFilters}
-                >
-                  Cancel
-                </AppButton>
-                <AppButton
-                  type="button"
-                  width="fit-content"
-                  onClick={() => {
-                    setDateFilter(selectedDaysFilter.value);
-                    setSideModalState({
-                      ...sideModalState,
-                      open: false,
-                      view: null,
-                    });
-                  }}
-                  disabled={
-                    dateFilter === selectedDaysFilter.value ||
-                    (isEmpty(dateFilter) && isEmpty(selectedDaysFilter))
-                  }
-                >
-                  Apply
-                </AppButton>
-              </FormGroup>
-            </FormGroup>
-          </FormWrapper>
-        );
-
       case MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_RECYCLE_OFFER:
         return (
           <CustomizeColumns
@@ -238,10 +167,25 @@ export function FollowUpRecycleOfferPage() {
     }
   };
 
+  const handleSelectTab = (value: any) => {
+    setDateFilter(value);
+  };
+
   return (
     <>
       <PageSubHeader
         withSearch
+        tabs={
+          <>
+            <Dropdown
+              menuItems={pageTabs}
+              defaultLabel={'No Filter'}
+              onSelect={handleSelectTab}
+              loading={isFetchingOrders}
+            />
+            <Divider />
+          </>
+        }
         rightControls={
           <>
             <IconButton
@@ -254,18 +198,6 @@ export function FollowUpRecycleOfferPage() {
                   view: MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_RECYCLE_OFFER,
                 });
               }}
-            />
-            <IconButton
-              tooltipLabel="Filter"
-              icon={faFilter}
-              onClick={() => {
-                setSideModalState({
-                  ...sideModalState,
-                  open: true,
-                  view: MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES,
-                });
-              }}
-              disabled={isFetchingOrders}
             />
             <Divider />
           </>
@@ -304,7 +236,7 @@ export function FollowUpRecycleOfferPage() {
           )}
         </div>
       </CenterModal>
-      <SideModal isOpen={sideModalState?.open} onClose={cancelFilters}>
+      <SideModal isOpen={sideModalState?.open} onClose={closeModal}>
         {renderSideModalContent()}
       </SideModal>
     </>

--- a/apps/tradein-admin/src/app/pages/actionables/followup-revision-offer/index.tsx
+++ b/apps/tradein-admin/src/app/pages/actionables/followup-revision-offer/index.tsx
@@ -1,15 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
-import { faFilter, faSliders } from '@fortawesome/free-solid-svg-icons';
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
 import {
-  AppButton,
+  ACTIONABLES_FOLLOW_UP_DEVICES_TABS,
   CenterModal,
   Column,
   CustomizeColumns,
   Divider,
-  FOLLOW_UP_DAYS_FILTER,
-  FormGroup,
-  FormWrapper,
+  Dropdown,
   IconButton,
   Loader,
   MODAL_TYPES,
@@ -20,7 +18,6 @@ import {
   REVISED_DEVICES_MANAGEMENT_COLUMNS,
   revisedDevicesManagementParsingConfig,
   SideModal,
-  StyledReactSelect,
   Table,
   useAuth,
   useCommon,
@@ -41,7 +38,6 @@ export function FollowUpRevisionOfferPage() {
   const [selectedRow, setSelectedRow] = useState<any>({});
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [dateFilter, setDateFilter] = useState<any>('');
-  const [selectedDaysFilter, setSelectedDaysFilter] = useState<any>(dateFilter);
 
   const customizedColumns = JSON.parse(localStorage.getItem('CC') || '{}');
   const savedColumns =
@@ -53,6 +49,8 @@ export function FollowUpRevisionOfferPage() {
   const [headers, setHeaders] = useState<Column[]>(
     savedColumns ?? defaultColumns,
   );
+
+  const pageTabs: any = [...ACTIONABLES_FOLLOW_UP_DEVICES_TABS];
 
   const filters = {
     page: Pages.REVISION_OFFER,
@@ -136,18 +134,7 @@ export function FollowUpRevisionOfferPage() {
     });
   }, [orders, dateFilter]);
 
-  const resetFilters = () => {
-    setSelectedDaysFilter('');
-  };
-
-  const cancelFilters = () => {
-    setDateFilter(dateFilter);
-    if (dateFilter) {
-      setSelectedDaysFilter({ ...selectedDaysFilter, value: dateFilter });
-    } else {
-      setSelectedDaysFilter('');
-    }
-
+  const closeModal = () => {
     setSideModalState({
       ...sideModalState,
       open: false,
@@ -157,64 +144,6 @@ export function FollowUpRevisionOfferPage() {
 
   const renderSideModalContent = () => {
     switch (sideModalState.view) {
-      case MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES:
-        return (
-          <FormWrapper formTitle="Filter By">
-            <FormGroup marginBottom="20px">
-              <StyledReactSelect
-                label="Days Filter"
-                name="days"
-                options={FOLLOW_UP_DAYS_FILTER}
-                isMulti={false}
-                placeholder="Set days filter"
-                value={selectedDaysFilter?.value}
-                onChange={(selectedOption) => {
-                  setSelectedDaysFilter(selectedOption);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <AppButton
-                type="button"
-                variant="outlined"
-                width="fit-content"
-                onClick={() => resetFilters()}
-                disabled={isEmpty(selectedDaysFilter)}
-              >
-                Reset
-              </AppButton>
-              <FormGroup>
-                <AppButton
-                  type="button"
-                  variant="outlined"
-                  width="fit-content"
-                  onClick={cancelFilters}
-                >
-                  Cancel
-                </AppButton>
-                <AppButton
-                  type="button"
-                  width="fit-content"
-                  onClick={() => {
-                    setDateFilter(selectedDaysFilter.value);
-                    setSideModalState({
-                      ...sideModalState,
-                      open: false,
-                      view: null,
-                    });
-                  }}
-                  disabled={
-                    dateFilter === selectedDaysFilter.value ||
-                    (isEmpty(dateFilter) && isEmpty(selectedDaysFilter))
-                  }
-                >
-                  Apply
-                </AppButton>
-              </FormGroup>
-            </FormGroup>
-          </FormWrapper>
-        );
-
       case MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_REVISION_OFFER:
         return (
           <CustomizeColumns
@@ -238,10 +167,25 @@ export function FollowUpRevisionOfferPage() {
     }
   };
 
+  const handleSelectTab = (value: any) => {
+    setDateFilter(value);
+  };
+
   return (
     <>
       <PageSubHeader
         withSearch
+        tabs={
+          <>
+            <Dropdown
+              menuItems={pageTabs}
+              defaultLabel={'No Filter'}
+              onSelect={handleSelectTab}
+              loading={isFetchingOrders}
+            />
+            <Divider />
+          </>
+        }
         rightControls={
           <>
             <IconButton
@@ -254,18 +198,6 @@ export function FollowUpRevisionOfferPage() {
                   view: MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_REVISION_OFFER,
                 });
               }}
-            />
-            <IconButton
-              tooltipLabel="Filter"
-              icon={faFilter}
-              onClick={() => {
-                setSideModalState({
-                  ...sideModalState,
-                  open: true,
-                  view: MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES,
-                });
-              }}
-              disabled={isFetchingOrders}
             />
             <Divider />
           </>
@@ -304,7 +236,7 @@ export function FollowUpRevisionOfferPage() {
           )}
         </div>
       </CenterModal>
-      <SideModal isOpen={sideModalState?.open} onClose={cancelFilters}>
+      <SideModal isOpen={sideModalState?.open} onClose={closeModal}>
         {renderSideModalContent()}
       </SideModal>
     </>

--- a/apps/tradein-admin/src/app/pages/actionables/followup-unsent-device/index.tsx
+++ b/apps/tradein-admin/src/app/pages/actionables/followup-unsent-device/index.tsx
@@ -1,15 +1,13 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable react-hooks/exhaustive-deps */
-import { faFilter, faSliders } from '@fortawesome/free-solid-svg-icons';
+import { faSliders } from '@fortawesome/free-solid-svg-icons';
 import {
-  AppButton,
+  ACTIONABLES_FOLLOW_UP_DEVICES_TABS,
   CenterModal,
   Column,
   CustomizeColumns,
   Divider,
-  FOLLOW_UP_DAYS_FILTER,
-  FormGroup,
-  FormWrapper,
+  Dropdown,
   IconButton,
   Loader,
   MODAL_TYPES,
@@ -18,7 +16,6 @@ import {
   Pages,
   PageSubHeader,
   SideModal,
-  StyledReactSelect,
   Table,
   UNSENT_DEVICES_MANAGEMENT_COLUMNS,
   unsentDevicesManagementParsingConfig,
@@ -41,7 +38,6 @@ export function FollowUpUnsentDevicePage() {
   const [selectedRow, setSelectedRow] = useState<any>({});
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [dateFilter, setDateFilter] = useState<any>('');
-  const [selectedDaysFilter, setSelectedDaysFilter] = useState<any>(dateFilter);
 
   const customizedColumns = JSON.parse(localStorage.getItem('CC') || '{}');
   const savedColumns =
@@ -53,6 +49,8 @@ export function FollowUpUnsentDevicePage() {
   const [headers, setHeaders] = useState<Column[]>(
     savedColumns ?? defaultColumns,
   );
+
+  const pageTabs: any = [...ACTIONABLES_FOLLOW_UP_DEVICES_TABS];
 
   const filters = {
     page: Pages.DEVICE_NOT_SENT,
@@ -135,18 +133,7 @@ export function FollowUpUnsentDevicePage() {
     });
   }, [orders, dateFilter]);
 
-  const resetFilters = () => {
-    setSelectedDaysFilter('');
-  };
-
-  const cancelFilters = () => {
-    setDateFilter(dateFilter);
-    if (dateFilter) {
-      setSelectedDaysFilter({ ...selectedDaysFilter, value: dateFilter });
-    } else {
-      setSelectedDaysFilter('');
-    }
-
+  const closeModal = () => {
     setSideModalState({
       ...sideModalState,
       open: false,
@@ -156,64 +143,6 @@ export function FollowUpUnsentDevicePage() {
 
   const renderSideModalContent = () => {
     switch (sideModalState.view) {
-      case MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES:
-        return (
-          <FormWrapper formTitle="Filter By">
-            <FormGroup marginBottom="20px">
-              <StyledReactSelect
-                label="Days Filter"
-                name="days"
-                options={FOLLOW_UP_DAYS_FILTER}
-                isMulti={false}
-                placeholder="Set days filter"
-                value={selectedDaysFilter?.value}
-                onChange={(selectedOption) => {
-                  setSelectedDaysFilter(selectedOption);
-                }}
-              />
-            </FormGroup>
-            <FormGroup>
-              <AppButton
-                type="button"
-                variant="outlined"
-                width="fit-content"
-                onClick={() => resetFilters()}
-                disabled={isEmpty(selectedDaysFilter)}
-              >
-                Reset
-              </AppButton>
-              <FormGroup>
-                <AppButton
-                  type="button"
-                  variant="outlined"
-                  width="fit-content"
-                  onClick={cancelFilters}
-                >
-                  Cancel
-                </AppButton>
-                <AppButton
-                  type="button"
-                  width="fit-content"
-                  onClick={() => {
-                    setDateFilter(selectedDaysFilter.value);
-                    setSideModalState({
-                      ...sideModalState,
-                      open: false,
-                      view: null,
-                    });
-                  }}
-                  disabled={
-                    dateFilter === selectedDaysFilter.value ||
-                    (isEmpty(dateFilter) && isEmpty(selectedDaysFilter))
-                  }
-                >
-                  Apply
-                </AppButton>
-              </FormGroup>
-            </FormGroup>
-          </FormWrapper>
-        );
-
       case MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_DEVICE_NOT_SENT:
         return (
           <CustomizeColumns
@@ -237,10 +166,25 @@ export function FollowUpUnsentDevicePage() {
     }
   };
 
+  const handleSelectTab = (value: any) => {
+    setDateFilter(value);
+  };
+
   return (
     <>
       <PageSubHeader
         withSearch
+        tabs={
+          <>
+            <Dropdown
+              menuItems={pageTabs}
+              defaultLabel={'No Filter'}
+              onSelect={handleSelectTab}
+              loading={isFetchingOrders}
+            />
+            <Divider />
+          </>
+        }
         rightControls={
           <>
             <IconButton
@@ -253,18 +197,6 @@ export function FollowUpUnsentDevicePage() {
                   view: MODAL_TYPES.CUSTOMIZE_COLUMNS_ACTIONABLES_FOLLOW_UP_DEVICE_NOT_SENT,
                 });
               }}
-            />
-            <IconButton
-              tooltipLabel="Filter"
-              icon={faFilter}
-              onClick={() => {
-                setSideModalState({
-                  ...sideModalState,
-                  open: true,
-                  view: MODAL_TYPES.FILTER_FOLLOW_UP_DEVICES,
-                });
-              }}
-              disabled={isFetchingOrders}
             />
             <Divider />
           </>
@@ -303,7 +235,7 @@ export function FollowUpUnsentDevicePage() {
           )}
         </div>
       </CenterModal>
-      <SideModal isOpen={sideModalState?.open} onClose={cancelFilters}>
+      <SideModal isOpen={sideModalState?.open} onClose={closeModal}>
         {renderSideModalContent()}
       </SideModal>
     </>

--- a/libs/src/constants/dropdown-items.tsx
+++ b/libs/src/constants/dropdown-items.tsx
@@ -1,4 +1,19 @@
+import { FollowUpDaysFilter } from './enums';
+
 export const PROMOTION_CLAIMS_TABS = [
   { label: 'Active', value: 'active' },
   { label: 'Closed', value: 'closed' },
+];
+
+export const ACTIONABLES_DEVICES_WITH_BOX_TABS = [
+  { label: 'To Print', value: 'to-print' },
+  { label: 'Prior Print', value: 'prior-print' },
+];
+
+export const ACTIONABLES_FOLLOW_UP_DEVICES_TABS = [
+  { label: 'No Filter', value: '' },
+  { label: '1-2 Days', value: FollowUpDaysFilter.TWO },
+  { label: '3-4 Days', value: FollowUpDaysFilter.FOUR },
+  { label: '5-6 Days', value: FollowUpDaysFilter.SIX },
+  { label: '7+ Days', value: FollowUpDaysFilter.SEVEN },
 ];


### PR DESCRIPTION
This PR includes the following changes:

- [ ] Replace the existing filter icon with a quick action filter button in Devices With Box Page
- [ ] Replace the existing filter icon with a quick action filter button in Follow-Up Device Not Sent Page
- [ ] Replace the existing filter icon with a quick action filter button in Follow-Up Device For Revision Page
- [ ] Replace the existing filter icon with a quick action filter button in Follow-Up Device For Recycle Page